### PR TITLE
Fix bug in item collision box

### DIFF
--- a/GameService/GameService/Game.cpp
+++ b/GameService/GameService/Game.cpp
@@ -375,7 +375,7 @@ bool Game::hasActionItemCollition(const CollisionDetector& collisionDetector, do
                                   QPointF(actionItem.location.x() + widthHalfActionItem, actionItem.location.y() + heightHalfActionItem));
         LineSegment rightActionItem(QPointF(actionItem.location.x() + widthHalfActionItem, actionItem.location.y() + heightHalfActionItem),
                                   QPointF(actionItem.location.x() + widthHalfActionItem, actionItem.location.y() - heightHalfActionItem));
-        LineSegment bottomActionItem(QPointF(actionItem.location.x() - widthHalfActionItem, actionItem.location.y() - heightHalfActionItem),
+        LineSegment bottomActionItem(QPointF(actionItem.location.x() + widthHalfActionItem, actionItem.location.y() - heightHalfActionItem),
                                   QPointF(actionItem.location.x() - widthHalfActionItem, actionItem.location.y() - heightHalfActionItem));
         LineSegment leftActionItem(QPointF(actionItem.location.x() - widthHalfActionItem, actionItem.location.y() - heightHalfActionItem),
                                   QPointF(actionItem.location.x() - widthHalfActionItem, actionItem.location.y() + heightHalfActionItem));


### PR DESCRIPTION
There is a bug in the collision box of action items. The bottom line has the same start and end coordinates, making it a point instead of a line.